### PR TITLE
return expected number of results when --stop is used

### DIFF
--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -308,6 +308,9 @@ def search(query, tld='com', lang='en', tbs='0', safe='off', num=10, start=0,
     # This is used to avoid repeated results.
     hashes = set()
 
+    # Count the number of links yielded
+    count = 0
+
     # Prepare domain list if it exists.
     if domains:
         domain_query = '+OR+'.join('site:' + domain for domain in domains)
@@ -391,6 +394,10 @@ def search(query, tld='com', lang='en', tbs='0', safe='off', num=10, start=0,
 
             # Yield the result.
             yield link
+
+            count += 1
+            if stop and count >= stop:
+                return
 
         # End if there are no more results.
         if not soup.find(id='nav'):


### PR DESCRIPTION
Count the number of urls being yielded. If `--stop` is used we can then stop when that number of links have been yielded.

This partially fixes #44.

Before
------

$ google --stop 5 arsenal
https://www.arsenal.com/
https://twitter.com/arsenal
http://www.skysports.com/arsenal
https://www.youtube.com/channel/UCpryVRk_VDudG8SHXgWcG0w
https://www.facebook.com/Arsenal/
https://en.wikipedia.org/wiki/Arsenal_F.C.
https://www.premierleague.com/clubs/1/Arsenal/overview
https://www.independent.co.uk/topic/Arsenal
https://www.mirror.co.uk/all-about/arsenal-fc

After
-----

$ google --stop 5 arsenal
https://www.arsenal.com/
https://twitter.com/arsenal
http://www.skysports.com/arsenal
https://www.youtube.com/channel/UCpryVRk_VDudG8SHXgWcG0w
https://www.facebook.com/Arsenal/
