### PR TITLE
Fix error when run in Google app engine or AWS

### DIFF
--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -150,7 +150,7 @@ def get_page(url, user_agent=None):
     response.close()
     try:
         cookie_jar.save()
-    except:
+    except Exception:
         pass
     return html
 

--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -148,7 +148,10 @@ def get_page(url, user_agent=None):
     cookie_jar.extract_cookies(response, request)
     html = response.read()
     response.close()
-    cookie_jar.save()
+    try:
+        cookie_jar.save()
+    except:
+        pass
     return html
 
 


### PR DESCRIPTION
Hi!
There is an error when I run this in GAE, I found that the cloud engine doesn't allow read and write local file, 
(https://stackoverflow.com/questions/50499190/google-app-engine-flex-wordpress-plugins-read-write-file-permissions)
so cookie_jar.save() will raise an error in this case. Adding try and except would fix this bug