### PR TITLE
Ignore dot in the hits number returned by Google

### DIFF
--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -732,7 +732,7 @@ def hits(query, tld='com', lang='en', tbs='0', safe='off',
 
     # Get the number of hits.
     tag = soup.find_all(attrs={"class": "sd", "id": "resultStats"})[0]
-    return int(tag.text.split()[1].replace(',', ''))
+    return int(tag.text.split()[1].replace(',', '').replace('.', ''))
 
 
 def ngd(term1, term2):


### PR DESCRIPTION
Google returns the number of hits with dot as the thousand separator
in the Netherlands, regardless of the passed `tld` and `lang`.
Fixes #60