### PR TITLE
Handle case without 'About' in hits

### DIFF
--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -754,7 +754,7 @@ def hits(query, tld='com', lang='en', tbs='0', safe='off',
     elif len(hits_text_parts) == 2:
         # case `7 results`
         hits_count_str = hits_text_parts[0]
-    else: 
+    else:
         # other cases
         return 0
     return int(hits_count_str.replace(',', '').replace('.', ''))

--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -744,7 +744,7 @@ def hits(query, tld='com', lang='en', tbs='0', safe='off',
     # Get the number of hits.
     tag = soup.find_all(attrs={"class": "sd", "id": "resultStats"})[0]
     # There are 2 possibilities here.
-    # `7 results` or 
+    # `7 results` or
     # `About 3,000,000,000 results`
     hits_text_parts = tag.text.split()
     hits_count_str = None
@@ -754,7 +754,8 @@ def hits(query, tld='com', lang='en', tbs='0', safe='off',
     elif len(hits_text_parts) == 2:
         # case `7 results`
         hits_count_str = hits_text_parts[0]
-    else: # other
+    else: 
+        # other cases
         return 0
     return int(hits_count_str.replace(',', '').replace('.', ''))
 

--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -743,10 +743,20 @@ def hits(query, tld='com', lang='en', tbs='0', safe='off',
 
     # Get the number of hits.
     tag = soup.find_all(attrs={"class": "sd", "id": "resultStats"})[0]
+    # There are 2 possibilities here.
+    # `7 results` or 
+    # `About 3,000,000,000 results`
     hits_text_parts = tag.text.split()
-    if len(hits_text_parts) < 3:
+    hits_count_str = None
+    if len(hits_text_parts) >= 3:
+        # case `About 3,000,000,000 results`
+        hits_count_str = hits_text_parts[1]
+    elif len(hits_text_parts) == 2:
+        # case `7 results`
+        hits_count_str = hits_text_parts[0]
+    else: # other
         return 0
-    return int(hits_text_parts[1].replace(',', '').replace('.', ''))
+    return int(hits_count_str.replace(',', '').replace('.', ''))
 
 
 def ngd(term1, term2):


### PR DESCRIPTION
For some queries with a small number of results, the `resultStats` div does not have the 'About' in it, causing the resulting `.split()` list to gives only 2 but not 3 elements. The `hits` function currently returns 0 for those cases. Therefore, we add code to handle those cases.

One example of a previously failing query is `site:example.com`, which has 1 result.

```py
from googlesearch import hits
hits('site:example.com') # which gives 0 incorrectly
``` 