### PR TITLE
Added proxy support for Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ Installing
 ----------
 
     pip install google
+
+
+Proxy support (Python 3+ only)
+------------------------------
+
+    # Get the first 20 hits for: "Breaking Code" WordPress blog
+    from googlesearch import search
+    for url in search('"Breaking Code" WordPress blog', stop=20, proxy=http:proxy.ip.address:proxy_port):
+        print(url)


### PR DESCRIPTION
## What's New

This PR implements proxy support for Python3 usage of the library. Now you can very easily use a proxy by passing a proxy `url` to the `proxy` argument for the `search` function:

```
from googlesearch import search
for url in search('"Breaking Code" WordPress blog', stop=20, proxy=http:proxy.ip.address:proxy_port):
    print(url)
```