### PR TITLE
Remove tables at top of page

### DIFF
--- a/googlesearch/__init__.py
+++ b/googlesearch/__init__.py
@@ -309,6 +309,11 @@ def search(query, tld='com', lang='en', tbs='0', safe='off', num=10, start=0,
             soup = BeautifulSoup(html, 'html.parser')
         else:
             soup = BeautifulSoup(html)
+
+        # Get rid of any table view at the top of the page
+        for table in soup.find_all('table'):
+            table.clear()
+
         try:
             anchors = soup.find(id='search').findAll('a')
             # Sometimes (depending on the User-agent) there is


### PR DESCRIPTION
Halfway fixes #110. While the logo is no longer detected, the Wikipedia link still is.

Another way I considered removing logo detection would be to check if the <a> contains text or not, and remove anchors which don't have text inside them.

To remove the Wikipedia link I think we'd need to walk the tree back up to the parent <div>, which feels brittle since there are layers of <div>'s and the markup could change.

<img width="759" alt="Screen Shot 2022-03-01 at 1 24 26 PM" src="https://user-images.githubusercontent.com/440033/156227111-3c72e5da-9da5-48eb-8e1d-9562e9b4e6d1.png">
